### PR TITLE
Updating single-account.yaml to lambda 3.12

### DIFF
--- a/cloudformation/emr_servicecatalog_templates/single-account.yaml
+++ b/cloudformation/emr_servicecatalog_templates/single-account.yaml
@@ -351,7 +351,7 @@ Resources:
         Fn::GetAtt:
         - CleanUpBucketonDeleteLambdaRole
         - Arn
-      Runtime: python3.7
+      Runtime: python3.12
       Timeout: 60
       Code:
         ZipFile:


### PR DESCRIPTION
*Issue #, if available:*
The runtime parameter of python3.7 is no longer supported for creating or updating AWS Lambda functions.

*Description of changes:*
Updated lambda to uuse python3.12 to resolve error

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
